### PR TITLE
Make non-async functions non-async

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -110,7 +110,7 @@ impl<'a> AiQueryContext<'a> {
         }
     }
 
-    pub async fn next_token(&mut self) -> Option<String> {
+    pub fn next_token(&mut self) -> Option<String> {
         if self.n_cur >= self.max_token {
             return None;
         }
@@ -161,7 +161,7 @@ mod tests {
 
     async fn process_tokens(mut query_context: AiQueryContext<'_>) -> usize {
         let mut count = 0;
-        while let Some(_token) = query_context.next_token().await {
+        while let Some(_token) = query_context.next_token() {
             count += 1;
         }
         count

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> std::io::Result<()> {
     env_logger::init();
 
     // set up the in-memory KV-store & load some knowledge.
-    let mut kv_store = rusty_llm::knowledge::get_db().await;
+    let mut kv_store = rusty_llm::knowledge::get_db();
     api::load_knowledge(
         path::Path::new(&std::env::var("DATA_PATH").unwrap_or("data".to_string())),
         &mut kv_store,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,7 +10,7 @@ mod tests {
             #[actix_web::test]
             async fn $name() {
                 $(
-                    let mut kv_store = rusty_llm::knowledge::get_db().await;
+                    let mut kv_store = rusty_llm::knowledge::get_db();
 
         let prompt = "<s>[INST]Using this information: {context} answer the Question: {query}[/INST]</s>".to_string();
                     rusty_llm::api::load_knowledge(std::path::Path::new("data/"), &mut kv_store).await;
@@ -52,7 +52,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_if_observability_works_example() {
-        let kv_store = rusty_llm::knowledge::get_db().await;
+        let kv_store = rusty_llm::knowledge::get_db();
 
         let prompt =
             "<s>[INST]Using this information: {context} answer the Question: {query}[/INST]</s>"


### PR DESCRIPTION
These are all blocking (they have no `await`s), so it's a lie to make them `async`. It also simplifies things for the upcoming PR.