### PR TITLE
Avoid blocking the event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,7 @@ dependencies = [
  "serde_json",
  "strfmt",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1653,6 +1654,17 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { version = "1.0.133" }
 serde = { version = "1.0.216", features = ["derive"] }
 strfmt = { version = "0.2.4" }
 tokio = { version = "1.42.0" }
+tokio-stream = "0.1.17"
 
 [lib]
 name = "rusty_llm"

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,8 +2,10 @@ use std::path;
 use std::time;
 
 use actix_web::web;
+use futures::StreamExt;
 use lazy_static::lazy_static;
 use llama_cpp_2::model;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::{ai, embedding, knowledge, EMBEDDING_TIME, REQUEST_RESPONSE_TIME};
 use prometheus::Encoder;
@@ -147,50 +149,59 @@ async fn stream_response(
     let backend = ai::init_backend();
 
     // To make this work with many models we take the last message as main query. The previous chat messages go in as context...
-    let query = &req_body.messages.last().unwrap().content;
+    let query = req_body.messages.last().unwrap().content.clone();
 
-    // Timing the embedding step
-    let embedding_start_time = time::Instant::now();
-    let tkn_query = embedding::embed(query, &EMBEDDING_MODEL, backend);
-    let mut context = knowledge::get_context(tkn_query, db.get_ref());
-    let embedding_duration = embedding_start_time.elapsed();
-    EMBEDDING_TIME
-        .with_label_values(&[])
-        .observe(embedding_duration.as_secs_f64());
+    let query_ = query.clone();
+    let context = match actix_web::web::block(move || {
+        // Timing the embedding step
+        let embedding_start_time = time::Instant::now();
+        let tkn_query = embedding::embed(&query_, &EMBEDDING_MODEL, backend);
+        let mut context = knowledge::get_context(tkn_query, db.get_ref());
+        let embedding_duration = embedding_start_time.elapsed();
+        EMBEDDING_TIME
+            .with_label_values(&[])
+            .observe(embedding_duration.as_secs_f64());
 
-    // ...now add the old chat stuff (if any)...
-    if req_body.messages.len() >= 3 {
-        context.extend(add_chat_history(&req_body.messages));
-    }
+        // ...now add the old chat stuff (if any)...
+        if req_body.messages.len() >= 3 {
+            context.extend(add_chat_history(&req_body.messages));
+        }
+        context
+    })
+    .await
+    {
+        Ok(context) => context,
+        Err(e) => {
+            return actix_web::HttpResponse::InternalServerError().body(e.to_string());
+        }
+    };
 
     // Initialize the AI query context
-    let ai_context = ai::AiQueryContext::new(
-        query,
-        context,
-        state.threads,
-        state.max_token,
-        &state.prompt,
-        &MODEL,
-        backend,
-    );
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let ai_worker = actix_web::rt::task::spawn_blocking(move || {
+        let mut ai_context = ai::AiQueryContext::new(
+            &query,
+            context,
+            state.threads,
+            state.max_token,
+            &state.prompt,
+            &MODEL,
+            backend,
+        );
+        while let Some(token) = ai_context.next_token() {
+            if tx.send(token).is_err() {
+                break;
+            }
+        }
+    });
 
     // Create a token stream
-    let token_stream = futures::stream::unfold(ai_context, |mut ai_context| async move {
-        match ai_context.next_token() {
-            Some(token) => {
-                let json_tmp = format!(
-                    r#"data: {{"id":"foo","object":"chat.completion.chunk","created":1733007600,"model":"{}", "system_fingerprint": "fp0", "choices":[{{"index":0,"delta":{{"content": "{}"}},"logprobs":null,"finish_reason":null}}]}}"#,
-                    "rusty_llm", token
-                );
-                // Not 100% why this is needed but without it the streaming does not work :-(
-                tokio::time::sleep(time::Duration::from_nanos(1)).await;
-                Some((
-                    Ok::<web::Bytes, actix_web::Error>(web::Bytes::from(json_tmp + "\n\n")),
-                    ai_context,
-                ))
-            }
-            None => None,
-        }
+    let token_stream = UnboundedReceiverStream::new(rx).map(|token| {
+        let json_tmp = format!(
+            r#"data: {{"id":"foo","object":"chat.completion.chunk","created":1733007600,"model":"{}", "system_fingerprint": "fp0", "choices":[{{"index":0,"delta":{{"content": "{}"}},"logprobs":null,"finish_reason":null}}]}}"#,
+            "rusty_llm", token
+        );
+        Ok::<_, actix_web::Error>(web::Bytes::from(json_tmp + "\n\n"))
     });
 
     // Measure the overall request-response time


### PR DESCRIPTION
So here's the final one. The `sleep` call was needed because the model evaluation was done right on the event loop, so there was no time to actually send the data to the client. Instead, move the evaluation and embedding to the blocking pool, and use a channel to stream the response tokens.